### PR TITLE
Improve keyboard focus for buttons

### DIFF
--- a/sectionheadRole.js
+++ b/sectionheadRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var sectionheadRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = sectionheadRole;
+exports.default = _default;


### PR DESCRIPTION
Adds a clear, accessible focus style for primary and secondary buttons to fix poor keyboard visibility. Updates button CSS to use :focus-visible with a 3px accent outline and adjusts padding to prevent layout shift.