### PR TITLE
Improve button focus visibility

### DIFF
--- a/ImageMapLinkRole.js
+++ b/ImageMapLinkRole.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var ImageMapLinkRole = {
+  relatedConcepts: [],
+  type: 'widget'
+};
+var _default = ImageMapLinkRole;
+exports["default"] = _default;


### PR DESCRIPTION
Enhance keyboard accessibility by restoring a visible focus ring on primary and secondary buttons, which was previously hard to detect. Adds :focus-visible styles with a 2px solid accent outline, removes conflicting box-shadow, and updates Storybook snapshots to reflect the change.