### PR TITLE
Improve button focus outline

### DIFF
--- a/isAxiosError.js
+++ b/isAxiosError.js
@@ -1,0 +1,14 @@
+'use strict';
+
+import utils from './../utils.js';
+
+/**
+ * Determines whether the payload is an error thrown by Axios
+ *
+ * @param {*} payload The value to test
+ *
+ * @returns {boolean} True if the payload is an error thrown by Axios, otherwise false
+ */
+export default function isAxiosError(payload) {
+  return utils.isObject(payload) && (payload.isAxiosError === true);
+}


### PR DESCRIPTION
Standardize the keyboard focus style for primary and secondary buttons to improve accessibility and visibility. Update CSS to use a 2px outline with the focus color variable (instead of box-shadow), ensuring consistent focus ring without layout shift.